### PR TITLE
Publish latest SDK version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="2.2.2"></a>
+## [2.2.2]
+
+### Bug Fixes
+- Livechat mode won't recover messages from closed case
+- In livechat mode the queue position will remain `null` as long as the agent is assigned to the case
+- SDK will supply Message object `createdAt` date with millisecond precision if possible
+- Fix missing `ChatThreadState.Closed` enum entry in api.txt
+
 <a name="2.2.1"></a>
 ## [2.2.1]
 
@@ -280,7 +289,8 @@
     - failure
   - typing start/end
 
-[Unreleased]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.1...HEAD
+[Unreleased]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.2...HEAD
+[2.2.2]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.2...2.2.1
 [2.2.1]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.1...2.2.0
 [2.2.0]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.1.1...2.2.0
 [2.1.1]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.1.0...2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="2.2.1"></a>
+## [2.2.1]
+
+### Bug Fixes
+- default `invoke()` operators in public API don't use `@JvmName` annotation to avoid minification issues in ProGuard/R8
+  - The API was extended with methods which have the same signature as was previously covered by `invoke()` operators.
+    This should prevent binary compatibility issues.
+- Fix missing contactId for live chat thread
+  - This fixes issue where it wasn't possible to end the live chat session in certain scenarios
+
 <a name="2.2.0"></a>
 ## [2.2.0]
 
@@ -10,8 +20,7 @@
   - Updated consumer-rules.pro to prevent minification of several problematic methods
   - Added rules to the internal SDK minification
 - SDK awaits for authorization
-  - [!NOTE]
-    Event sending may be delayed until server confirms user authorization to use Chat service,
+  - ℹ️ Event sending may be delayed until server confirms user authorization to use Chat service,
     sending of events prior to this could lead to loss of such events.
 ### Dependency Change
 - Bump kotlin from 2.0.0 to 2.0.10
@@ -271,7 +280,8 @@
     - failure
   - typing start/end
 
-[Unreleased]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.0...HEAD
+[Unreleased]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.1...HEAD
+[2.2.1]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.2.1...2.2.0
 [2.2.0]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.1.1...2.2.0
 [2.1.1]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/nice-devone/nice-cxone-mobile-sdk-android/compare/2.0.0...2.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ plugins {
 }
 
 group = GROUP
-version = "2.2.0" // Fallback version
+version = "2.2.1" // Fallback version
 
 allprojects {
     group = rootProject.group

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ plugins {
 }
 
 group = GROUP
-version = "2.2.1" // Fallback version
+version = "2.2.2" // Fallback version
 
 allprojects {
     group = rootProject.group

--- a/chat-sdk-core/api.txt
+++ b/chat-sdk-core/api.txt
@@ -966,6 +966,7 @@ package com.nice.cxonechat.thread {
   @com.nice.cxonechat.Public public enum ChatThreadState {
     method public static com.nice.cxonechat.thread.ChatThreadState valueOf(String value) throws java.lang.IllegalArgumentException, java.lang.NullPointerException;
     method public static com.nice.cxonechat.thread.ChatThreadState[] values();
+    enum_constant public static final com.nice.cxonechat.thread.ChatThreadState Closed;
     enum_constant public static final com.nice.cxonechat.thread.ChatThreadState Loaded;
     enum_constant public static final com.nice.cxonechat.thread.ChatThreadState Pending;
     enum_constant public static final com.nice.cxonechat.thread.ChatThreadState Ready;

--- a/chat-sdk-core/api.txt
+++ b/chat-sdk-core/api.txt
@@ -58,8 +58,10 @@ package com.nice.cxonechat {
   @com.nice.cxonechat.Public public interface ChatBuilder {
     method @Deprecated @CheckResult public com.nice.cxonechat.Cancellable build(com.nice.cxonechat.ChatBuilder.OnChatBuiltCallback callback);
     method @CheckResult public com.nice.cxonechat.Cancellable build(com.nice.cxonechat.ChatBuilder.OnChatBuiltResultCallback resultCallback);
-    method public default static operator com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config);
-    method public default static operator com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config, optional com.nice.cxonechat.log.Logger logger);
+    method public default static com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config);
+    method public default static com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config, optional com.nice.cxonechat.log.Logger logger);
+    method public default static operator com.nice.cxonechat.ChatBuilder invoke(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config);
+    method public default static operator com.nice.cxonechat.ChatBuilder invoke(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config, optional com.nice.cxonechat.log.Logger logger);
     method public com.nice.cxonechat.ChatBuilder setAuthorization(com.nice.cxonechat.Authorization authorization);
     method public com.nice.cxonechat.ChatBuilder setChatStateListener(com.nice.cxonechat.ChatStateListener listener);
     method public com.nice.cxonechat.ChatBuilder setCustomerId(String customerId);
@@ -70,8 +72,10 @@ package com.nice.cxonechat {
   }
 
   @com.nice.cxonechat.Public public static final class ChatBuilder.Companion {
-    method public operator com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config);
-    method public operator com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config, optional com.nice.cxonechat.log.Logger logger);
+    method public com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config);
+    method public com.nice.cxonechat.ChatBuilder getDefault(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config, optional com.nice.cxonechat.log.Logger logger);
+    method public operator com.nice.cxonechat.ChatBuilder invoke(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config);
+    method public operator com.nice.cxonechat.ChatBuilder invoke(android.content.Context context, com.nice.cxonechat.SocketFactoryConfiguration config, optional com.nice.cxonechat.log.Logger logger);
   }
 
   @com.nice.cxonechat.Public public static fun interface ChatBuilder.OnChatBuiltCallback {
@@ -347,12 +351,14 @@ package com.nice.cxonechat {
   }
 
   @com.nice.cxonechat.Public public interface SocketFactoryConfiguration {
-    method public default static operator com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId);
-    method @Deprecated public default static operator com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId, optional String version);
+    method public default static com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId);
+    method @Deprecated public default static com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId, optional String version);
     method public long getBrandId();
     method public String getChannelId();
     method public com.nice.cxonechat.state.Environment getEnvironment();
     method @Deprecated public String getVersion();
+    method public default static operator com.nice.cxonechat.SocketFactoryConfiguration invoke(com.nice.cxonechat.state.Environment environment, long brandId, String channelId);
+    method @Deprecated public default static operator com.nice.cxonechat.SocketFactoryConfiguration invoke(com.nice.cxonechat.state.Environment environment, long brandId, String channelId, optional String version);
     property public abstract long brandId;
     property public abstract String channelId;
     property public abstract com.nice.cxonechat.state.Environment environment;
@@ -361,8 +367,10 @@ package com.nice.cxonechat {
   }
 
   @com.nice.cxonechat.Public public static final class SocketFactoryConfiguration.Companion {
-    method public operator com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId);
-    method @Deprecated public operator com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId, optional String version);
+    method public com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId);
+    method @Deprecated public com.nice.cxonechat.SocketFactoryConfiguration create(com.nice.cxonechat.state.Environment environment, long brandId, String channelId, optional String version);
+    method public operator com.nice.cxonechat.SocketFactoryConfiguration invoke(com.nice.cxonechat.state.Environment environment, long brandId, String channelId);
+    method @Deprecated public operator com.nice.cxonechat.SocketFactoryConfiguration invoke(com.nice.cxonechat.state.Environment environment, long brandId, String channelId, optional String version);
   }
 
   @com.nice.cxonechat.Public public interface UserName {

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/ChatBuilder.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/ChatBuilder.kt
@@ -162,10 +162,28 @@ interface ChatBuilder {
          * @see OnChatBuiltCallback
          * @see OnChatBuiltCallback.onChatBuilt
          * */
-        @JvmName("getDefault")
         @JvmOverloads
         @JvmStatic
         operator fun invoke(
+            context: Context,
+            config: SocketFactoryConfiguration,
+            logger: Logger = LoggerNoop,
+        ): ChatBuilder = getDefault(context, config, logger)
+
+        /**
+         * Returns an instance of [ChatBuilder] with Android specific parameters.
+         *
+         * @param context The [Context] used for persistent storage of values by the SDK.
+         * @param config [SocketFactoryConfiguration] connection configuration of the chat.
+         * @param logger [Logger] which will be used by the builder and the SDK, default is no-op implementation.
+         *
+         * @see build
+         * @see OnChatBuiltCallback
+         * @see OnChatBuiltCallback.onChatBuilt
+         * */
+        @JvmOverloads
+        @JvmStatic
+        fun getDefault(
             context: Context,
             config: SocketFactoryConfiguration,
             logger: Logger = LoggerNoop,

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/ChatThreadHandler.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/ChatThreadHandler.kt
@@ -16,7 +16,9 @@
 package com.nice.cxonechat
 
 import androidx.annotation.CheckResult
+import com.nice.cxonechat.exceptions.InvalidStateException
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
 
 /**
  * Instance of a thread handler. This instance will contain the most up-to-date
@@ -99,7 +101,10 @@ interface ChatThreadHandler {
     /**
      * Terminate the contact.
      *
-     * @throws InvalidStateException if the current channel is not a live chat.
+     * @throws InvalidStateException if the current channel is not a live chat,
+     * or if the [ChatThread.threadState] isn't in state [ChatThreadState.Ready],
+     * or [ChatThreadState.Closed].
+     *
      */
     fun endContact()
 

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/SocketFactoryConfiguration.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/SocketFactoryConfiguration.kt
@@ -63,29 +63,55 @@ interface SocketFactoryConfiguration {
          *
          * @see SocketFactoryConfiguration
          */
-        @JvmName("create")
         @JvmStatic
-        @Suppress("DEPRECATION")
         operator fun invoke(
             environment: Environment,
             brandId: Long,
             channelId: String,
-        ) = invoke(environment, brandId, channelId, BuildConfig.VERSION_NAME)
+        ) = create(environment, brandId, channelId)
 
         /**
          * Helper method to create a new configuration.
          *
          * @see SocketFactoryConfiguration
          */
-        @JvmName("create")
         @JvmStatic
         @Deprecated("This method is deprecated for public usage and will be removed from public API.")
+        @Suppress("DEPRECATION")
         operator fun invoke(
             environment: Environment,
             brandId: Long,
             channelId: String,
             version: String = BuildConfig.VERSION_NAME,
-        ) = object : SocketFactoryConfiguration {
+        ) = create(environment, brandId, channelId, version)
+
+        /**
+         * Helper method to create a new configuration.
+         *
+         * @see SocketFactoryConfiguration
+         */
+        @JvmStatic
+        @Suppress("DEPRECATION")
+        fun create(
+            environment: Environment,
+            brandId: Long,
+            channelId: String,
+        ): SocketFactoryConfiguration = create(environment, brandId, channelId, BuildConfig.VERSION_NAME)
+
+        /**
+         * Helper method to create a new configuration.
+         *
+         * @see SocketFactoryConfiguration
+         */
+        @JvmStatic
+        @Suppress("DEPRECATION")
+        @Deprecated("This method is deprecated for public usage and will be removed from public API.")
+        fun create(
+            environment: Environment,
+            brandId: Long,
+            channelId: String,
+            version: String = BuildConfig.VERSION_NAME,
+        ): SocketFactoryConfiguration = object : SocketFactoryConfiguration {
             override val environment = environment
             override val brandId = brandId
             override val channelId = channelId

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/CaseStatusChangedHandlerActions.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/CaseStatusChangedHandlerActions.kt
@@ -20,6 +20,7 @@ import com.nice.cxonechat.internal.model.ChatThreadMutable
 import com.nice.cxonechat.internal.model.network.EventCaseStatusChanged
 import com.nice.cxonechat.internal.model.network.EventCaseStatusChanged.CaseStatus.Closed
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
 
 internal object CaseStatusChangedHandlerActions {
     inline fun handleCaseClosed(
@@ -31,7 +32,12 @@ internal object CaseStatusChangedHandlerActions {
             val notArchived = event.status !== Closed
             val canAddMoreMessagesChanged = notArchived != thread.canAddMoreMessages
             if (canAddMoreMessagesChanged) {
-                thread.update(thread.asCopyable().copy(canAddMoreMessages = notArchived))
+                thread.update(
+                    thread.asCopyable().copy(
+                        canAddMoreMessages = notArchived,
+                        threadState = if (!notArchived) ChatThreadState.Closed else thread.threadState
+                    )
+                )
                 onThreadUpdate(thread)
             }
         }

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/ChatThreadHandlerLiveChat.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/ChatThreadHandlerLiveChat.kt
@@ -76,7 +76,7 @@ internal class ChatThreadHandlerLiveChat(
             .addCallback<EventSetPositionInQueue>(SetPositionInQueue) { event ->
                 thread += thread.asCopyable().copy(
                     contactId = event.consumerContact,
-                    positionInQueue = event.positionInQueue,
+                    positionInQueue = if (thread.threadAgent == null) event.positionInQueue else null,
                     hasOnlineAgent = event.hasOnlineAgent,
                 )
                 filteringListener.onUpdated(thread)
@@ -124,6 +124,7 @@ internal class ChatThreadHandlerLiveChat(
     }
 
     private fun updateFromEvent(event: EventLiveChatThreadRecovered) {
+        if (event.threadState === Closed) return
         val messages = event.messages.sortedBy(Message::createdAt)
         val eventThread = event.thread
         thread += thread.asCopyable().copy(

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/ChatThreadHandlerMessages.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/ChatThreadHandlerMessages.kt
@@ -45,6 +45,8 @@ internal class ChatThreadHandlerMessages(
             val message = event.message
             if (!event.inThread(thread) || thread.messages.contains(message)) return@addCallback
             thread += thread.asCopyable().copy(
+                contactId = event.contactId,
+                threadState = event.threadState,
                 messages = thread.messages.updateWith(listOfNotNull(message))
             )
             listener.onUpdated(thread)

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/ChatThreadsHandlerLive.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/ChatThreadsHandlerLive.kt
@@ -34,8 +34,6 @@ import com.nice.cxonechat.internal.model.network.EventLiveChatThreadRecovered
 import com.nice.cxonechat.internal.socket.ErrorCallback.Companion.addErrorCallback
 import com.nice.cxonechat.internal.socket.EventCallback.Companion.addCallback
 import com.nice.cxonechat.thread.ChatThread
-import com.nice.cxonechat.thread.ChatThreadState.Loaded
-import com.nice.cxonechat.thread.ChatThreadState.Ready
 
 internal class ChatThreadsHandlerLive(
     private val chat: ChatWithParameters,
@@ -103,7 +101,7 @@ internal class ChatThreadsHandlerLive(
         } else {
             eventThread.asCopyable().copy(
                 messages = event.messages.removeConversationStarter(),
-                threadState = if (event.agent != null) Ready else Loaded
+                threadState = event.threadState
             )
         }
         return recovered

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/EventLiveChatThreadRecovered.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/EventLiveChatThreadRecovered.kt
@@ -15,10 +15,12 @@
 
 package com.nice.cxonechat.internal.model.network
 
+import com.nice.cxonechat.enums.ContactStatus
 import com.nice.cxonechat.internal.model.AgentModel
 import com.nice.cxonechat.internal.model.CustomFieldModel
 import com.nice.cxonechat.internal.model.MessageModel
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -43,6 +45,13 @@ internal data class EventLiveChatThreadRecovered(
     val scrollToken get() = data.messagesScrollToken
     val customerCustomFields get() = data.customer?.customFields.orEmpty().map(CustomFieldModel::toCustomField)
     val lastContactStatus get() = data.contact?.status
+    val threadState get() = if (lastContactStatus === ContactStatus.Closed) {
+        ChatThreadState.Closed
+    } else if (thread?.contactId != null) {
+        ChatThreadState.Ready
+    } else {
+        ChatThreadState.Loaded
+    }
 
     fun inThread(thread: ChatThread) = thread.id == this.thread?.id &&
             messages.all { it.threadId == thread.id }

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/EventMessageCreated.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/EventMessageCreated.kt
@@ -15,12 +15,14 @@
 
 package com.nice.cxonechat.internal.model.network
 
+import com.nice.cxonechat.enums.ContactStatus
 import com.nice.cxonechat.enums.EventType.MessageCreated
 import com.nice.cxonechat.internal.model.Contact
 import com.nice.cxonechat.internal.model.MessageModel
 import com.nice.cxonechat.internal.model.Thread
 import com.nice.cxonechat.internal.socket.EventCallback.ReceivedEvent
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -38,6 +40,13 @@ internal data class EventMessageCreated(
     val threadName get() = data.thread.threadName
 
     val message get() = data.message.toMessage()
+
+    val threadState
+        get() = if (contactStatus === ContactStatus.Closed) {
+            ChatThreadState.Closed
+        } else {
+            ChatThreadState.Ready
+        }
 
     fun inThread(thread: ChatThread): Boolean = thread.id == threadId
 

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/EventThreadRecovered.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/EventThreadRecovered.kt
@@ -21,6 +21,7 @@ import com.nice.cxonechat.internal.model.CustomFieldModel
 import com.nice.cxonechat.internal.model.MessageModel
 import com.nice.cxonechat.internal.socket.EventCallback.ReceivedEvent
 import com.nice.cxonechat.thread.ChatThread
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
@@ -47,6 +48,7 @@ internal data class EventThreadRecovered(
             messages.all { it.threadId == thread.id }
 
     @Serializable
+    @OptIn(ExperimentalSerializationApi::class)
     data class Data(
         @SerialName("messages")
         val messages: List<MessageModel>?,

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/ReceivedThreadData.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/ReceivedThreadData.kt
@@ -25,6 +25,7 @@ import java.util.Date
 import java.util.UUID
 
 @Serializable
+@SerialName("thread") // Not required, but it hides internal class name
 internal data class ReceivedThreadData(
     @SerialName("id")
     internal val id: String,

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/RecoverThreadData.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/model/network/RecoverThreadData.kt
@@ -43,6 +43,7 @@ internal data class RecoverThreadData(
         ) : ThreadSpecification
 
         @Serializable
+        @SerialName("no_thread_id") // Not required, but it hides internal class name
         data object EmptySpecification : ThreadSpecification
     }
 

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/serializer/Default.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/internal/serializer/Default.kt
@@ -137,7 +137,7 @@ internal object Default {
         val dateFormatter: SimpleDateFormat
             get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("IsoDateSerializer", PrimitiveKind.STRING)
-        override fun serialize(encoder: Encoder, value: IsoDate) = encoder.encodeString(dateFormatter.format(value))
+        override fun serialize(encoder: Encoder, value: IsoDate) = encoder.encodeString(dateFormatter.format(value.date))
         override fun deserialize(decoder: Decoder): IsoDate {
             val date = dateFormatter.parse(decoder.decodeString()) ?: throw IsoDateSerializationException()
             return IsoDate(

--- a/chat-sdk-core/src/main/java/com/nice/cxonechat/thread/ChatThreadState.kt
+++ b/chat-sdk-core/src/main/java/com/nice/cxonechat/thread/ChatThreadState.kt
@@ -38,5 +38,10 @@ enum class ChatThreadState {
      * A thread that is completely ready for use, either because it was locally created or
      * because both the metadata and thread details have been recovered.
      */
-    Ready
+    Ready,
+
+    /**
+     * The thread was closed, no more messages or events should be sent via its handler.
+     */
+    Closed
 }

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadHandlerLiveChatTest.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadHandlerLiveChatTest.kt
@@ -15,18 +15,28 @@
 
 package com.nice.cxonechat
 
+import com.nice.cxonechat.exceptions.InvalidStateException
 import com.nice.cxonechat.internal.copy.ChatThreadCopyable.Companion.asCopyable
 import com.nice.cxonechat.internal.model.ChatThreadMutable
 import com.nice.cxonechat.internal.model.ChatThreadMutable.Companion.asMutable
+import com.nice.cxonechat.internal.model.CustomFieldInternal
+import com.nice.cxonechat.internal.model.MessageModel
 import com.nice.cxonechat.internal.model.network.EventCaseStatusChanged.CaseStatus.Closed
+import com.nice.cxonechat.model.makeAgent
 import com.nice.cxonechat.model.makeChatThread
+import com.nice.cxonechat.model.makeCustomField
+import com.nice.cxonechat.model.makeMessageModel
 import com.nice.cxonechat.server.ServerResponse
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
+import com.nice.cxonechat.thread.CustomField
+import com.nice.cxonechat.tool.nextString
 import org.junit.Test
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-internal class ChatThreadHandlerLiveChatTest: AbstractChatTest() {
+internal class ChatThreadHandlerLiveChatTest : AbstractChatTest() {
 
     private lateinit var chatThread: ChatThreadMutable
     private lateinit var thread: ChatThreadHandler
@@ -40,13 +50,63 @@ internal class ChatThreadHandlerLiveChatTest: AbstractChatTest() {
     @Test
     fun get_observes_case_closed() {
         val expected = chatThread.asCopyable().copy(
-            canAddMoreMessages = false
+            canAddMoreMessages = false,
+            threadState = ChatThreadState.Closed,
         )
         assertNotEquals<ChatThread>(chatThread, expected)
         val actual = testCallback(::get) {
             sendServerMessage(ServerResponse.CaseStatusChanged(chatThread.snapshot(), Closed))
         }
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun livechat_recovered_updates_thread() {
+        val messages = listOf(
+            makeMessageModel(),
+            makeMessageModel()
+        )
+        val scrollToken = nextString()
+        val agent = makeAgent()
+        val caseCustomFields = listOf(
+            makeCustomField(),
+            makeCustomField()
+        )
+        val expected = chatThread.asCopyable().copy(
+            contactId = TestContactId,
+            scrollToken = scrollToken,
+            threadAgent = agent.toAgent(),
+            messages = messages.mapNotNull(MessageModel::toMessage),
+            threadState = ChatThreadState.Ready,
+            threadName = nextString(),
+            fields = caseCustomFields
+        )
+        assertNotEquals(chatThread, expected.asMutable())
+        val actual = testCallback(::get) {
+            sendServerMessage(ServerResponse.LivechatRecovered(
+                thread = expected,
+                messages = messages.toTypedArray(),
+                scrollToken = scrollToken,
+                agent = agent
+            ))
+        }
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun endContact_when_closed_does_nothing() {
+        chatThread.update(chatThread.asCopyable().copy(threadState = ChatThreadState.Closed))
+        assertSendsNothing {
+            thread.endContact()
+        }
+    }
+
+    @Test(expected = InvalidStateException::class)
+    fun endContact_throws_when_not_ready() {
+        chatThread.update(chatThread.asCopyable().copy(threadState = ChatThreadState.Loaded))
+        assertSendsNothing {
+            thread.endContact()
+        }
     }
 
     // ---

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadHandlerTest.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadHandlerTest.kt
@@ -198,6 +198,7 @@ internal class ChatThreadHandlerTest : AbstractChatTest() {
             threadIdOnExternalPlatform = id
         )
         val expected = chatThread.asCopyable().copy(
+            contactId = TestContactId,
             messages = listOfNotNull(messageModel.toMessage())
         )
         val actual = testCallback(::get) {
@@ -214,7 +215,7 @@ internal class ChatThreadHandlerTest : AbstractChatTest() {
         )
         val message = messageModel.toMessage()
         assertNotNull(message)
-        updateChatThread(chatThread.asCopyable().copy(messages = listOf(message)))
+        updateChatThread(chatThread.asCopyable().copy(messages = listOf(message), contactId = TestContactId))
         val actual = testCallback(::get) {
             sendServerMessage(ServerResponse.MessageCreated(chatThread, messageModel))
         }
@@ -234,12 +235,13 @@ internal class ChatThreadHandlerTest : AbstractChatTest() {
             userStatistics = makeUserStatistics(seenAt = Date(0))
         )
         val expected = chatThread.asCopyable().copy(
+            contactId = TestContactId,
             messages = listOfNotNull(updatedMessage.toMessage())
         )
         val actual = testCallback(::get) {
             sendServerMessage(ServerResponse.MessageCreated(chatThread, updatedMessage))
         }
-        assertEquals(actual, expected)
+        assertEquals(expected, actual)
     }
 
     @Test

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadsHandlerLiveChatTest.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadsHandlerLiveChatTest.kt
@@ -20,7 +20,7 @@ import com.nice.cxonechat.internal.model.network.EventCaseStatusChanged.CaseStat
 import com.nice.cxonechat.model.makeChatThread
 import com.nice.cxonechat.server.ServerResponse
 import com.nice.cxonechat.thread.ChatThread
-import com.nice.cxonechat.thread.ChatThreadState.Ready
+import com.nice.cxonechat.thread.ChatThreadState
 import com.nice.cxonechat.thread.ChatThreadState.Received
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -40,7 +40,11 @@ internal class ChatThreadsHandlerLiveChatTest : AbstractChatTest() {
     fun threads_notifies_caseClosed() {
         connect()
         val initial = makeChatThread(threadState = Received)
-        val expected = initial.copy(canAddMoreMessages = false, threadState = Ready, contactId = TestContactId)
+        val expected = initial.copy(
+            canAddMoreMessages = false,
+            threadState = ChatThreadState.Closed,
+            contactId = TestContactId,
+        )
         val actual = testCallback(::threads) {
             sendServerMessage(ServerResponse.LivechatRecovered(thread = initial))
             sendServerMessage(ServerResponse.CaseStatusChanged(expected, Closed))

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadsHandlerTest.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/ChatThreadsHandlerTest.kt
@@ -28,6 +28,7 @@ import com.nice.cxonechat.model.makeMessageModel
 import com.nice.cxonechat.server.ServerRequest
 import com.nice.cxonechat.server.ServerResponse
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
 import com.nice.cxonechat.thread.ChatThreadState.Loaded
 import com.nice.cxonechat.thread.ChatThreadState.Received
 import org.junit.Test
@@ -111,7 +112,10 @@ internal class ChatThreadsHandlerTest : AbstractChatTest() {
     fun threads_notifies_caseClosed() {
         val initial = List(2) { makeChatThread(threadState = Received) }
         val expected = initial.toMutableList().also {
-            it[0] = it[0].copy(canAddMoreMessages = false)
+            it[0] = it[0].copy(
+                canAddMoreMessages = false,
+                threadState = ChatThreadState.Closed,
+            )
         }
         assertEquals(true, initial[0].canAddMoreMessages)
         val actual = testCallback(::threads) {

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/model/CustomField.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/model/CustomField.kt
@@ -13,19 +13,19 @@
  * FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
  */
 
-package com.nice.cxonechat.ui.composable.conversation.model
+package com.nice.cxonechat.model
 
-import androidx.compose.runtime.Stable
-import com.nice.cxonechat.thread.ChatThreadState
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
+import com.nice.cxonechat.internal.model.CustomFieldInternal
+import com.nice.cxonechat.thread.CustomField
+import com.nice.cxonechat.tool.nextString
+import java.util.Date
 
-@Stable
-internal data class ConversationTopBarState(
-    val threadName: Flow<String?>,
-    val isMultiThreaded: Boolean,
-    val hasQuestions: Boolean,
-    val isLiveChat: Boolean,
-    val isArchived: StateFlow<Boolean>,
-    val threadState: StateFlow<ChatThreadState>,
+internal fun makeCustomField(
+    id: String = nextString(),
+    value: String = nextString(),
+    updatedAt: Date = Date(0),
+) : CustomField = CustomFieldInternal(
+    id = id,
+    value = value,
+    updatedAt = updatedAt,
 )

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/server/ServerResponse.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/server/ServerResponse.kt
@@ -298,7 +298,7 @@ internal object ServerResponse {
         val data = object {
             val message = message
             val case = object {
-                val id = "id"
+                val id = TestContactId
                 val threadIdOnExternalPlatform = thread.id
                 val status = "new"
                 val createdAt = Date(0)

--- a/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/server/ServerResponse.kt
+++ b/chat-sdk-core/src/testDebug/java/com/nice/cxonechat/server/ServerResponse.kt
@@ -34,6 +34,7 @@ import com.nice.cxonechat.model.makeAgent
 import com.nice.cxonechat.model.makeChatThread
 import com.nice.cxonechat.model.makeMessageModel
 import com.nice.cxonechat.model.toReceived
+import com.nice.cxonechat.state.Connection
 import com.nice.cxonechat.thread.ChatThread
 import com.nice.cxonechat.thread.CustomField
 import com.nice.cxonechat.tool.nextString
@@ -405,6 +406,32 @@ internal object ServerResponse {
                 val thread = thread.toReceived()
                 val messagesScrollToken = scrollToken
             }
+        }
+    }.serialize()
+
+    fun CaseInboxAssigneeChanged(
+        thread: ChatThread,
+        agent: AgentModel?,
+        connection: Connection,
+    ) = object {
+        val eventId = TestUUID
+        val eventType = "CaseInboxAssigneeChanged".also { assert(it == EventType.CaseInboxAssigneeChanged.value) }
+        val createdAt = DateTime(Date(0))
+        val data = object {
+            val channel = object {
+                val id = connection.channelId
+            }
+            val brand = object {
+                val id = connection.brandId
+            }
+            val case = object {
+                val id = thread.contactId ?: TestContactId
+                val threadIdOnExternalPlatform = thread.id
+                val status = New.value
+                val createdAt = DateTime(Date(0))
+                val statusUpdatedAt = DateTime(Date(0))
+            }
+            val inboxAssignee = agent
         }
     }.serialize()
 

--- a/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/ChatActivity.kt
+++ b/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/ChatActivity.kt
@@ -169,9 +169,8 @@ class ChatActivity : ComponentActivity() {
     private fun setupComposableUi() {
         setContent {
             ChatTheme {
-                val chatState by chatStateViewModel.state.collectAsState()
                 val snackbarHostState = remember { SnackbarHostState() }
-                HandleEarlyChatState(snackbarHostState) {
+                HandleEarlyChatState(snackbarHostState) { chatState ->
                     ChatUi(chatState, snackbarHostState)
                 }
             }
@@ -179,7 +178,7 @@ class ChatActivity : ComponentActivity() {
     }
 
     @Composable
-    private fun HandleEarlyChatState(snackbarHostState: SnackbarHostState, onChatReady: @Composable () -> Unit) {
+    private fun HandleEarlyChatState(snackbarHostState: SnackbarHostState, onChatReady: @Composable (ChatState) -> Unit) {
         val state by chatStateViewModel.state.collectAsState()
         val context = LocalContext.current
         when (state) {
@@ -197,7 +196,7 @@ class ChatActivity : ComponentActivity() {
                 )
             }
 
-            else -> onChatReady()
+            else -> onChatReady(state)
         }
     }
 
@@ -300,12 +299,13 @@ class ChatActivity : ComponentActivity() {
     @Composable
     private fun ThreadViewTopBar(isMultiThread: Boolean, isLiveChat: Boolean) {
         val threadNameFlow = remember { chatThreadViewModel.chatMetadata.map { it.threadName } }
+        val hasQuestions = remember { chatThreadViewModel.hasQuestions }
         ChatThreadTopBar(
             conversationState = ConversationTopBarState(
                 threadName = threadNameFlow,
                 isMultiThreaded = isMultiThread,
                 isLiveChat = isLiveChat,
-                hasQuestions = chatThreadViewModel.hasQuestions,
+                hasQuestions = hasQuestions,
                 isArchived = chatThreadViewModel.isArchived,
                 threadState = chatThreadViewModel.threadStateFlow,
             ),

--- a/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/ChatActivity.kt
+++ b/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/ChatActivity.kt
@@ -307,6 +307,7 @@ class ChatActivity : ComponentActivity() {
                 isLiveChat = isLiveChat,
                 hasQuestions = chatThreadViewModel.hasQuestions,
                 isArchived = chatThreadViewModel.isArchived,
+                threadState = chatThreadViewModel.threadStateFlow,
             ),
             onEditThreadName = { chatThreadViewModel.editThreadName() },
             onEditThreadValues = chatThreadViewModel::startEditingCustomValues,

--- a/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/main/ChatThreadViewModel.kt
+++ b/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/main/ChatThreadViewModel.kt
@@ -42,6 +42,7 @@ import com.nice.cxonechat.message.OutboundMessage
 import com.nice.cxonechat.prechat.PreChatSurvey
 import com.nice.cxonechat.thread.Agent
 import com.nice.cxonechat.thread.ChatThread
+import com.nice.cxonechat.thread.ChatThreadState
 import com.nice.cxonechat.thread.CustomField
 import com.nice.cxonechat.ui.customvalues.CustomValueItemList
 import com.nice.cxonechat.ui.customvalues.extractStringValues
@@ -181,6 +182,10 @@ internal class ChatThreadViewModel(
             if (it && isLiveChat) showEndContactDialog()
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
+
+    val threadStateFlow: StateFlow<ChatThreadState> = chatThreadFlow
+        .mapLatest { it.threadState }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ChatThreadState.Pending)
 
     val maxAttachmentSize: Int
         get() = chat.configuration.fileRestrictions.allowedFileSize

--- a/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/main/ChatThreadViewModel.kt
+++ b/chat-sdk-ui/src/main/java/com/nice/cxonechat/ui/main/ChatThreadViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024. NICE Ltd. All rights reserved.
+ * Copyright (c) 2021-2025. NICE Ltd. All rights reserved.
  *
  * Licensed under the NICE License;
  * you may not use this file except in compliance with the License.
@@ -178,8 +178,14 @@ internal class ChatThreadViewModel(
     val isArchived: StateFlow<Boolean> = chatThreadFlow
         .mapLatest { !it.canAddMoreMessages }
         .distinctUntilChanged()
-        .onEach {
-            if (it && isLiveChat) showEndContactDialog()
+        .onEach { isArchived ->
+            if (isLiveChat) {
+                if (isArchived) {
+                    showEndContactDialog()
+                } else if (Dialogs.EndContact == dialogShown.value) {
+                    dismissDialog()
+                }
+            }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
 
@@ -449,6 +455,7 @@ internal class ChatThreadViewModel(
             override val variables: Map<String, Any?>,
             val metadata: ActionMetadata,
         ) : PopupActionState, PopupActionData
+
         data class PreviewPopupAction(
             override val variables: Map<String, Any?>,
             val metadata: Any,

--- a/chat-sdk-ui/src/main/res/values/strings.xml
+++ b/chat-sdk-ui/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="chat_state_connection_lost_action_reconnect">Reconnect</string>
     <string name="chat_state_error_default_message">SDK has encountered error</string>
     <string name="chat_state_error_action_close">Close Chat</string>
+    <string name="chat_state_offline">The chat is Offline</string>
 
     <string name="edit_custom_field_title">Edit pre-chat survey custom fields</string>
 


### PR DESCRIPTION
## [2.2.2]

### Bug Fixes
- Livechat mode won't recover messages from closed case
- In livechat mode the queue position will remain `null` as long as the agent is assigned to the case
- SDK will supply Message object `createdAt` date with millisecond precision if possible
- Fix missing `ChatThreadState.Closed` enum entry in api.txt